### PR TITLE
Fix for Android Keyboard Issue

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -31,7 +31,7 @@ const scrollToBottom = () => {
 }
 
 function userInputHandler(e : KeyboardEvent) {
-  const key = e.code;
+  const key = e.key;
 
   switch(key) {
     case "Enter":


### PR DESCRIPTION
Hey

Using `e.key` instead of `e.code` fixes the keyboard issue on Android (and maybe other ones as well).

Reference:
[KeyboardEvent: code property](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code)
[KeyboardEvent: key property](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key)